### PR TITLE
refactor: include api-key header with dms-zs communication

### DIFF
--- a/src/main/configurations/xxllnc/Configuration_Handler_AddDocumentToCaseCommand.xml
+++ b/src/main/configurations/xxllnc/Configuration_Handler_AddDocumentToCaseCommand.xml
@@ -125,8 +125,11 @@
                     contentType="text/xml"
                     timeout="${openforms2xxllnc.connections.ontvang-asynchroon.timeout}"
                     throwApplicationFaults="false"
+                    headersParams="x-opentunnel-api-key"
+                    parametersToSkipWhenEmpty="*"
                     >
                     <Param name="url" value="${openforms2xxllnc.connections.ontvang-asynchroon.endpoint}" />
+                    <Param name="x-opentunnel-api-key" pattern="{password}" authAlias="${openforms2xxllnc.connections.ontvang-asynchroon.auth-alias}" hidden="true" />
                 </WebServiceSender>
                 <Forward name="success" path="UnwrapBv03BerichtResponse" />
                 <Forward name="exception" path="SoapFault_Exception" />

--- a/src/main/configurations/xxllnc/Configuration_Workflow_TwoWayCommunication.xml
+++ b/src/main/configurations/xxllnc/Configuration_Workflow_TwoWayCommunication.xml
@@ -96,8 +96,11 @@
                     contentType="text/xml"
                     timeout="${openforms2xxllnc.connections.beantwoord-vraag.timeout}"
                     throwApplicationFaults="false"
+                    headersParams="x-opentunnel-api-key"
+                    parametersToSkipWhenEmpty="*"
                     >
                     <Param name="url" value="${openforms2xxllnc.connections.beantwoord-vraag.endpoint}" />
+                    <Param name="x-opentunnel-api-key" pattern="{password}" authAlias="${openforms2xxllnc.connections.beantwoord-vraag.auth-alias}" hidden="true" />
                 </WebServiceSender>
                 <Forward name="success" path="UnwrapZakLa01Response" />
                 <Forward name="exception" path="SoapFault_Exception" />

--- a/src/main/resources/DeploymentSpecifics.properties
+++ b/src/main/resources/DeploymentSpecifics.properties
@@ -41,10 +41,13 @@ ladybug.jdbc.datasource=
 ##
 openforms2xxllnc.connections.beantwoord-vraag.endpoint: http://host.docker.internal:8080/services/translate/generic/zds/BeantwoordVraag
 openforms2xxllnc.connections.beantwoord-vraag.timeout: 60000
+openforms2xxllnc.connections.beantwoord-vraag.auth-alias: zaakdms-api
 openforms2xxllnc.connections.ontvang-asynchroon.endpoint: http://host.docker.internal:8080/services/translate/generic/zds/OntvangAsynchroon
 openforms2xxllnc.connections.ontvang-asynchroon.timeout: 60000
+openforms2xxllnc.connections.ontvang-asynchroon.auth-alias: zaakdms-api
 openforms2xxllnc.connections.vrije-berichten.endpoint: http://host.docker.internal:8080/services/translate/generic/zds/VrijBericht
 openforms2xxllnc.connections.vrije-berichten.timeout: 60000
+openforms2xxllnc.connections.vrije-berichten.auth-alias: zaakdms-api
 ## @param openforms2xxllnc.connections.notificatiesApi.rootUrl [string] Root url of the 'Notificaties API' that is used to subscribe at.
 ## @param openforms2xxllnc.connections.notificatiesApi.timeout Timeout used in 'Notificaties API' calls.
 ## @param openforms2xxllnc.connections.notificatiesApi.authType [string] Options: 'jwt', 'basic', 'value'. 'value' uses the password field of the given authAlias as Authorization header.

--- a/src/main/secrets/credentials.properties
+++ b/src/main/secrets/credentials.properties
@@ -9,5 +9,6 @@ documenten-api/password=secret1234
 notificaties-api/username=nrc
 notificaties-api/password=nrc
 objects-api/password=Token secret1234
+zaakdms-api/password=secret1234
 noreply-smtp/username=noreply@frank-smtp
 noreply-smtp/password=secret1234


### PR DESCRIPTION
A new auth-alias added and its password value is assigned to the parameter named "x-opentunnel-api-key" and this parameter is added to header for the requests that are done to zds.