### PR TITLE
fix: use identificatie from genereerDocumentIdentificatie in voegZaakdocumentToe request & add dct.omschrijving to voegZaakdocumentToe request with value from property

### DIFF
--- a/e2e/SoapUI/openforms2xxllnc-e2e-soapui-project.xml
+++ b/e2e/SoapUI/openforms2xxllnc-e2e-soapui-project.xml
@@ -3130,6 +3130,27 @@ should be used. If `height` is nested inside `dimensions` attribute, query shoul
       <con:settings/>
     </con:operation>
   </con:interface>
+  <con:interface xsi:type="con:WsdlInterface" id="cdd682d8-83ae-42f9-b158-1a18812889ff" wsaVersion="NONE" name="SOAPVrijeBerichten" type="wsdl" bindingName="{http://www.egem.nl/StUF/sector/zkn/0310}SOAPVrijeBerichten" soapVersion="1_1" anonymous="optional" definition="file:/C:/Users/Meric/Workspace/openforms2xxllnc/src/main/configurations/xxllnc/Common/xsd/Zaak_DocumentServices_1_1_02/zkn0310/zs-dms/zkn0310_vrijeBerichten_zs-dms.wsdl" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <con:settings/>
+    <con:endpoints>
+      <con:endpoint>http://example.com/VrijeBerichten</con:endpoint>
+    </con:endpoints>
+    <con:operation id="b1464e30-a5fb-4662-a830-096451474a8f" isOneWay="false" action="http://www.egem.nl/StUF/sector/zkn/0310/cancelCheckout_Di02" name="cancelCheckout_Di02" bindingOperationName="cancelCheckout_Di02" type="Request-Response" inputName="" receivesAttachments="false" sendsAttachments="false">
+      <con:settings/>
+    </con:operation>
+    <con:operation id="69583d57-0244-4d1d-a95f-ac69215407bc" isOneWay="false" action="http://www.egem.nl/StUF/sector/zkn/0310/geefZaakdocumentbewerken_Di02" name="geefZaakdocumentbewerken_Di02" bindingOperationName="geefZaakdocumentbewerken_Di02" type="Request-Response" inputName="" receivesAttachments="false" sendsAttachments="false">
+      <con:settings/>
+    </con:operation>
+    <con:operation id="42a8717b-4ebc-4b1f-a1d2-851697950cbd" isOneWay="false" action="http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02" name="genereerDocumentIdentificatie_Di02" bindingOperationName="genereerDocumentIdentificatie_Di02" type="Request-Response" inputName="" receivesAttachments="false" sendsAttachments="false">
+      <con:settings/>
+    </con:operation>
+    <con:operation id="5a98fc52-27f3-4c42-9d1e-14990b9db7ae" isOneWay="false" action="http://www.egem.nl/StUF/sector/zkn/0310/genereerZaakIdentificatie_Di02" name="genereerZaakIdentificatie_Di02" bindingOperationName="genereerZaakIdentificatie_Di02" type="Request-Response" inputName="" receivesAttachments="false" sendsAttachments="false">
+      <con:settings/>
+    </con:operation>
+    <con:operation id="7ceb90d7-ec87-4885-8f1c-72824537c3f1" isOneWay="false" action="http://www.egem.nl/StUF/sector/zkn/0310/updateZaakdocument_Di02" name="updateZaakdocument_Di02" bindingOperationName="updateZaakdocument_Di02" type="Request-Response" inputName="" receivesAttachments="false" sendsAttachments="false">
+      <con:settings/>
+    </con:operation>
+  </con:interface>
   <con:testSuite id="51faa60a-6964-478d-8f14-899c806b2805" name="e2e">
     <con:settings/>
     <con:runType>SEQUENTIAL</con:runType>
@@ -5001,7 +5022,7 @@ casesServiceMock.setPropertyValue("initiatingSubjectCitizenNumber", initiatingSu
           <con:parameters/>
         </con:config>
       </con:testStep>
-      <con:properties></con:properties>
+      <con:properties/>
     </con:testCase>
     <con:testCase id="23b78cc4-169c-4fce-af0d-59483ded296b" failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="tweewegcommunicatie CaseNotFoundBedrijf" searchProperties="true">
       <con:settings/>
@@ -5290,7 +5311,7 @@ casesServiceMock.setPropertyValue("initiatingSubjectCitizenNumber", initiatingSu
           <con:parameters/>
         </con:config>
       </con:testStep>
-      <con:properties></con:properties>
+      <con:properties/>
     </con:testCase>
     <con:testCase id="ebca3ff5-f51f-4bf6-9348-0b76b904cd2f" failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="tweewegcommunicatie SubjectNotEqualsCaseSubjectBSN" searchProperties="true">
       <con:settings/>
@@ -5320,7 +5341,7 @@ casesServiceMock.setPropertyValue("initiatingSubjectCitizenNumber", '123456789')
       <con:testStep type="restrequest" name="objects_object_create" id="1cded775-4584-4a33-bd90-17242153a8de">
         <con:settings/>
         <con:config service="Objects API" methodName="object_create" resourcePath="/objects" xsi:type="con:RestRequestStep" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-          <con:restRequest name="Copy of objects_object_create" id="ed424109-4058-4072-9e27-fa17d227f6a0" mediaType="application/json" postQueryString="false">
+          <con:restRequest name="objects_object_create" id="ed424109-4058-4072-9e27-fa17d227f6a0" mediaType="application/json" postQueryString="false">
             <con:settings>
               <con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment/></con:setting>
             </con:settings>
@@ -6133,7 +6154,7 @@ casesServiceMock.setPropertyValue("initiatingSubjectCitizenNumber", '123456789')
           <con:parameters/>
         </con:config>
       </con:testStep>
-      <con:properties></con:properties>
+      <con:properties/>
     </con:testCase>
     <con:testCase id="143c2143-699e-4517-9d32-8082e8a45a37" failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="tweewegcommunicatie NoKvK" searchProperties="true">
       <con:settings/>
@@ -6416,7 +6437,7 @@ casesServiceMock.setPropertyValue("initiatingSubjectCitizenNumber", '123456789')
           <con:parameters/>
         </con:config>
       </con:testStep>
-      <con:properties></con:properties>
+      <con:properties/>
     </con:testCase>
     <con:testCase id="45ddaeba-6e47-46eb-bb47-cc15a0dccaee" failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="tweewegcommunicatie ClosedCasePersoon" searchProperties="true">
       <con:settings/>
@@ -6705,7 +6726,7 @@ casesServiceMock.setPropertyValue("initiatingSubjectCitizenNumber", initiatingSu
           <con:parameters/>
         </con:config>
       </con:testStep>
-      <con:properties></con:properties>
+      <con:properties/>
     </con:testCase>
     <con:testCase id="00227535-29a4-4034-b4bc-b988bb5a1fde" failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="tweewegcommunicatie ClosedCaseBedrijf" searchProperties="true">
       <con:settings/>
@@ -6994,7 +7015,7 @@ casesServiceMock.setPropertyValue("initiatingSubjectCitizenNumber", initiatingSu
           <con:parameters/>
         </con:config>
       </con:testStep>
-      <con:properties></con:properties>
+      <con:properties/>
     </con:testCase>
     <con:properties/>
   </con:testSuite>
@@ -7370,6 +7391,44 @@ casesServiceMock.setPropertyValue("initiatingSubjectCitizenNumber", initiatingSu
           <con:response>CaseFoundBedrijfClosedCase</con:response>
         </con:query>
       </con:dispatchConfig>
+    </con:mockOperation>
+  </con:mockService>
+  <con:mockService id="c879355d-3434-4937-a220-89f5c8a74d58" port="8097" path="/mock/services/translate/generic/zds/VrijBericht" host="LAPTOP-R4K3GHC" name="ZDS-VrijeBerichten-Mock" bindToHostOnly="false" docroot="">
+    <con:settings>
+      <con:setting id="com.eviware.soapui.impl.wsdl.mock.WsdlMockService@require-soap-action">false</con:setting>
+    </con:settings>
+    <con:properties/>
+    <con:mockOperation name="genereerDocumentIdentificatie_Di02" id="71e4fb29-24c5-4b24-9e39-99e39c4086cb" interface="SOAPVrijeBerichten" operation="genereerDocumentIdentificatie_Di02">
+      <con:settings/>
+      <con:defaultResponse>Response 1</con:defaultResponse>
+      <con:dispatchStyle>SEQUENCE</con:dispatchStyle>
+      <con:response name="Response 1" id="7c217952-d745-4371-a9d8-ae4503f925b0" httpResponseStatus="200" encoding="UTF-8">
+        <con:settings/>
+        <con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Body><ZKN:genereerDocumentIdentificatie_Du02 xmlns:StUF="http://www.egem.nl/StUF/StUF0301" xmlns:ZKN="http://www.egem.nl/StUF/sector/zkn/0310" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+   <ZKN:stuurgegevens>
+      <StUF:berichtcode>Du02</StUF:berichtcode>
+      <StUF:zender>
+         <StUF:organisatie>1900</StUF:organisatie>
+         <StUF:applicatie>zs-dms</StUF:applicatie>
+      </StUF:zender>
+      <StUF:ontvanger>
+         <StUF:organisatie>1900</StUF:organisatie>
+         <StUF:applicatie>Openforms2xxllnc</StUF:applicatie>
+         <StUF:gebruiker></StUF:gebruiker>
+      </StUF:ontvanger>
+      <StUF:referentienummer>ac150004-579477bd_192bb3d0d17_-7fcf</StUF:referentienummer>
+      <StUF:tijdstipBericht>20241023232701</StUF:tijdstipBericht>
+      <StUF:crossRefnummer>ac150004-579477bd_192bb3d0d17_-7fcf</StUF:crossRefnummer>
+      <StUF:functie>genereerDocumentidentificatie</StUF:functie>
+   </ZKN:stuurgegevens>
+   <ZKN:document StUF:entiteittype="EDC" StUF:functie="entiteit">
+      <ZKN:identificatie>${#Project#documentIdentificatie}</ZKN:identificatie>
+   </ZKN:document>
+</ZKN:genereerDocumentIdentificatie_Du02>
+</soapenv:Body></soapenv:Envelope>]]></con:responseContent>
+        <con:wsaConfig mustUnderstand="NONE" version="200508" action="http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02"/>
+      </con:response>
+      <con:dispatchConfig/>
     </con:mockOperation>
   </con:mockService>
   <con:restMockService id="d63c7861-f9bf-4330-8cab-d5b197f52c85" port="8700" path="/mock/documenten/api/v1" host="LAPTOP-UKAI1A6" name="Documenten API Mock" docroot="">
@@ -8098,6 +8157,10 @@ if( requestBody.contains("some data") )
     <con:property>
       <con:name>initiatingSubjectKvkNumber</con:name>
       <con:value>823288444</con:value>
+    </con:property>
+    <con:property>
+      <con:name>documentIdentificatie</con:name>
+      <con:value>DC2024-00001</con:value>
     </con:property>
   </con:properties>
   <con:wssContainer/>

--- a/src/main/configurations/xxllnc/Common/xsl/CreateGenereerDocumentIdentificatie_Di02Request.xslt
+++ b/src/main/configurations/xxllnc/Common/xsl/CreateGenereerDocumentIdentificatie_Di02Request.xslt
@@ -1,0 +1,10 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:StUF="http://www.egem.nl/StUF/StUF0301" xmlns:ZKN="http://www.egem.nl/StUF/sector/zkn/0310" xmlns:xmime="http://www.w3.org/2005/05/xmlmime" version="2.0">
+	<xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes"/>
+    <xsl:param name="Stuurgegevens" as="node()?" />
+   
+	<xsl:template match="/">
+        <ZKN:genereerDocumentIdentificatie_Di02>
+            <xsl:copy-of select="$Stuurgegevens/ZKN:stuurgegevens" />
+        </ZKN:genereerDocumentIdentificatie_Di02>
+	</xsl:template>
+</xsl:stylesheet>

--- a/src/main/configurations/xxllnc/Common/xsl/CreateObjectLk01.xslt
+++ b/src/main/configurations/xxllnc/Common/xsl/CreateObjectLk01.xslt
@@ -14,7 +14,7 @@
                     <ZKN:identificatie><xsl:value-of select="$DocumentIdentificatie"/></ZKN:identificatie>
                 </xsl:when>
             </xsl:choose>
-            <ZKN:dct.omschrijving>Brief</ZKN:dct.omschrijving> <!-- Test purposes-->
+            <!-- <ZKN:dct.omschrijving>Brief</ZKN:dct.omschrijving> Test purposes -->
             <ZKN:creatiedatum><xsl:value-of select="format-date(ZgwEnkelvoudigInformatieObject/creatiedatum, '[Y0001][M01][D01]')"/></ZKN:creatiedatum>
             <xsl:choose>
                 <xsl:when test="ZgwEnkelvoudigInformatieObject/ontvangstdatum != ''" >

--- a/src/main/configurations/xxllnc/Common/xsl/CreateObjectLk01.xslt
+++ b/src/main/configurations/xxllnc/Common/xsl/CreateObjectLk01.xslt
@@ -10,11 +10,7 @@
 
     <xsl:template match="/">
         <ZKN:object StUF:entiteittype="EDC" StUF:verwerkingssoort="T">
-            <xsl:choose>
-                <xsl:when test="ZgwEnkelvoudigInformatieObject/identificatie != ''" >
-                    <ZKN:identificatie><xsl:value-of select="$DocumentIdentificatie"/></ZKN:identificatie>
-                </xsl:when>
-            </xsl:choose>
+            <ZKN:identificatie><xsl:value-of select="$DocumentIdentificatie"/></ZKN:identificatie>
             <ZKN:dct.omschrijving><xsl:value-of select="$DctOmschrijving"/></ZKN:dct.omschrijving>
             <ZKN:creatiedatum><xsl:value-of select="format-date(ZgwEnkelvoudigInformatieObject/creatiedatum, '[Y0001][M01][D01]')"/></ZKN:creatiedatum>
             <xsl:choose>

--- a/src/main/configurations/xxllnc/Common/xsl/CreateObjectLk01.xslt
+++ b/src/main/configurations/xxllnc/Common/xsl/CreateObjectLk01.xslt
@@ -1,6 +1,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:StUF="http://www.egem.nl/StUF/StUF0301" xmlns:ZKN="http://www.egem.nl/StUF/sector/zkn/0310" xmlns:xmime="http://www.w3.org/2005/05/xmlmime" version="2.0">
     <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes"/>
     <xsl:param name="DocumentIdentificatie"/>
+    <xsl:param name="DctOmschrijving"/>
     <xsl:param name="Base64Inhoud"/>
     <xsl:param name="CaseReferenceNumber"/>
     <xsl:param name="CaseDescription"/>
@@ -14,7 +15,7 @@
                     <ZKN:identificatie><xsl:value-of select="$DocumentIdentificatie"/></ZKN:identificatie>
                 </xsl:when>
             </xsl:choose>
-            <!-- <ZKN:dct.omschrijving>Brief</ZKN:dct.omschrijving> Test purposes -->
+            <ZKN:dct.omschrijving><xsl:value-of select="$DctOmschrijving"/></ZKN:dct.omschrijving>
             <ZKN:creatiedatum><xsl:value-of select="format-date(ZgwEnkelvoudigInformatieObject/creatiedatum, '[Y0001][M01][D01]')"/></ZKN:creatiedatum>
             <xsl:choose>
                 <xsl:when test="ZgwEnkelvoudigInformatieObject/ontvangstdatum != ''" >

--- a/src/main/configurations/xxllnc/Common/xsl/CreateObjectLk01.xslt
+++ b/src/main/configurations/xxllnc/Common/xsl/CreateObjectLk01.xslt
@@ -1,5 +1,6 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:StUF="http://www.egem.nl/StUF/StUF0301" xmlns:ZKN="http://www.egem.nl/StUF/sector/zkn/0310" xmlns:xmime="http://www.w3.org/2005/05/xmlmime" version="2.0">
     <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes"/>
+    <xsl:param name="DocumentIdentificatie"/>
     <xsl:param name="Base64Inhoud"/>
     <xsl:param name="CaseReferenceNumber"/>
     <xsl:param name="CaseDescription"/>
@@ -10,7 +11,7 @@
         <ZKN:object StUF:entiteittype="EDC" StUF:verwerkingssoort="T">
             <xsl:choose>
                 <xsl:when test="ZgwEnkelvoudigInformatieObject/identificatie != ''" >
-                    <ZKN:identificatie><xsl:value-of select="ZgwEnkelvoudigInformatieObject/identificatie"/></ZKN:identificatie>
+                    <ZKN:identificatie><xsl:value-of select="$DocumentIdentificatie"/></ZKN:identificatie>
                 </xsl:when>
             </xsl:choose>
             <ZKN:dct.omschrijving>Brief</ZKN:dct.omschrijving> <!-- Test purposes-->

--- a/src/main/configurations/xxllnc/Common/xsl/CreateStuurgegevens.xslt
+++ b/src/main/configurations/xxllnc/Common/xsl/CreateStuurgegevens.xslt
@@ -7,6 +7,7 @@
     <xsl:param name="OntvangerApplicatie"/>
     <xsl:param name="Referentienummer"/>
     <xsl:param name="EntiteitType"/>
+    <xsl:param name="Functie"/>
    
 	<xsl:template match="/">
         <ZKN:stuurgegevens>
@@ -21,7 +22,14 @@
             </StUF:ontvanger>
             <StUF:referentienummer><xsl:value-of select="$Referentienummer"/></StUF:referentienummer>
             <StUF:tijdstipBericht><xsl:value-of select="format-dateTime(current-dateTime(), '[Y0001][M01][D01][H01][m01][s01]')"/></StUF:tijdstipBericht>
-            <StUF:entiteittype><xsl:value-of select="$EntiteitType"/></StUF:entiteittype>
+            <xsl:choose>
+                <xsl:when test="$EntiteitType != ''">
+                    <StUF:entiteittype><xsl:value-of select="$EntiteitType"/></StUF:entiteittype>
+                </xsl:when>
+                <xsl:otherwise>
+                    <StUF:functie><xsl:value-of select="$Functie"/></StUF:functie>
+                </xsl:otherwise>
+            </xsl:choose>
         </ZKN:stuurgegevens>
 	</xsl:template>
 </xsl:stylesheet>

--- a/src/main/configurations/xxllnc/Configuration.xml
+++ b/src/main/configurations/xxllnc/Configuration.xml
@@ -13,6 +13,7 @@
     <!ENTITY WorkflowSelector SYSTEM "./Configuration_WorkflowSelector.xml">
     <!ENTITY WrapEdcLk01Request SYSTEM "./Configuration_WrapEdcLk01Request.xml">
     <!ENTITY WrapZakLv01Request SYSTEM "./Configuration_WrapZakLv01Request.xml">
+    <!ENTITY WrapDi02Request SYSTEM "./Configuration_WrapGenereerDocumentIdentificatie_Di02Request.xml">
     ]>
 
 <configuration name="xxllnc">
@@ -30,4 +31,5 @@
     &WorkflowSelector;
     &WrapEdcLk01Request;
     &WrapZakLv01Request;
+    &WrapDi02Request;
 </configuration>

--- a/src/main/configurations/xxllnc/Configuration_Handler_AddDocumentToCaseCommand.xml
+++ b/src/main/configurations/xxllnc/Configuration_Handler_AddDocumentToCaseCommand.xml
@@ -90,8 +90,60 @@
                 lineLength="0"
                 storeResultInSessionKey="ZgwEnkelvoudigInformatieObjectInhoud"
                 >
-                <Forward name="success" path="CallWrapEdcLk01Request" />
+                <Forward name="success" path="CallWrapGenereerDocumentIdentificatie_Di02Request" />
             </Base64Pipe>
+
+            <!-- Create genereerDocumentIdentificatie message -->
+            <SenderPipe 
+                name="CallWrapGenereerDocumentIdentificatie_Di02Request"
+                getInputFromFixedValue="&lt;EmptyInput/&gt;"
+                storeResultInSessionKey="GenereerDocumentIdentificatie_Di02RequestMessage"
+                >
+                <IbisLocalSender
+                    name="CallWrapGenereerDocumentIdentificatie_Di02RequestSender"
+                    javaListener="WrapGenereerDocumentIdentificatie_Di02Request"
+                    returnedSessionKeys="Error"
+                    >
+                </IbisLocalSender>
+                <Forward name="success" path="GenereerDocumentIdentificatieSender" />
+            </SenderPipe>
+
+            <SenderPipe
+                name="GenereerDocumentIdentificatieSender"
+                getInputFromSessionKey="GenereerDocumentIdentificatie_Di02RequestMessage"
+                >
+                <WebServiceSender
+                    name="GenereerDocumentIdentificatieWebServiceSender"
+                    soap="false"
+                    soapAction="http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02"
+                    contentType="text/xml"
+                    timeout="${openforms2xxllnc.connections.vrije-berichten.timeout}"
+                    throwApplicationFaults="false"
+                    headersParams="x-opentunnel-api-key"
+                    parametersToSkipWhenEmpty="*"
+                    >
+                    <Param name="url" value="${openforms2xxllnc.connections.vrije-berichten.endpoint}" />
+                    <Param name="x-opentunnel-api-key" pattern="{password}" authAlias="${openforms2xxllnc.connections.vrije-berichten.auth-alias}" hidden="true" />
+                </WebServiceSender>
+                <Forward name="success" path="UnwrapGenereerDocumentIdentificatie_Du02Response" />
+                <Forward name="exception" path="SoapFault_Exception" />
+            </SenderPipe>
+
+            <SoapWrapperPipe 
+                name="UnwrapGenereerDocumentIdentificatie_Du02Response"
+                storeResultInSessionKey="UnwrappedGenereerDocumentIdentificatie_Du02Response"
+                direction="UNWRAP"
+                removeOutputNamespaces="true"
+                >
+                <Forward name="success" path="StoreDocumentIdentificatie" />
+            </SoapWrapperPipe>
+
+            <PutInSessionPipe
+                name="StoreDocumentIdentificatie"
+                >
+                <Param name="DocumentIdentificatie" xpathExpression="//document/identificatie" />
+                <Forward name="success" path="CallWrapEdcLk01Request" />
+            </PutInSessionPipe>
 
             <!-- Create VoegZaakdocumentToe message -->
             <SenderPipe 
@@ -105,6 +157,7 @@
                     returnedSessionKeys="Error"
                     >
                     <Param name="ZgwEnkelvoudigInformatieObject" sessionKey="ZgwEnkelvoudigInformatieObject" />
+                    <Param name="DocumentIdentificatie" sessionKey="DocumentIdentificatie" />
                     <Param name="Base64Inhoud" sessionKey="ZgwEnkelvoudigInformatieObjectInhoud" />
                     <Param name="CaseReferenceNumber" sessionKey="CaseReferenceNumber" />
                     <Param name="CaseDescription" sessionKey="CaseDescription" />

--- a/src/main/configurations/xxllnc/Configuration_WrapEdcLk01Request.xml
+++ b/src/main/configurations/xxllnc/Configuration_WrapEdcLk01Request.xml
@@ -50,6 +50,7 @@
                 styleSheetName="Common/xsl/CreateObjectLk01.xslt"
                 storeResultInSessionKey="Object"
                 >
+                <Param name="DocumentIdentificatie" sessionKey="DocumentIdentificatie" />
                 <Param name="Base64Inhoud" sessionKey="Base64Inhoud" />
                 <Param name="CaseReferenceNumber" sessionKey="CaseReferenceNumber" />
                 <Param name="CaseDescription" sessionKey="CaseDescription" />

--- a/src/main/configurations/xxllnc/Configuration_WrapEdcLk01Request.xml
+++ b/src/main/configurations/xxllnc/Configuration_WrapEdcLk01Request.xml
@@ -51,6 +51,7 @@
                 storeResultInSessionKey="Object"
                 >
                 <Param name="DocumentIdentificatie" sessionKey="DocumentIdentificatie" />
+                <Param name="DctOmschrijving" value="${openforms2xxllnc.workflows.object.dct.omschrijving}" />
                 <Param name="Base64Inhoud" sessionKey="Base64Inhoud" />
                 <Param name="CaseReferenceNumber" sessionKey="CaseReferenceNumber" />
                 <Param name="CaseDescription" sessionKey="CaseDescription" />

--- a/src/main/configurations/xxllnc/Configuration_WrapGenereerDocumentIdentificatie_Di02Request.xml
+++ b/src/main/configurations/xxllnc/Configuration_WrapGenereerDocumentIdentificatie_Di02Request.xml
@@ -1,0 +1,49 @@
+<Module xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../FrankConfig.xsd">
+    <Adapter name="WrapGenereerDocumentIdentificatie_Di02Request"
+        active="${WrapGenereerDocumentIdentificatie_Di02Request.Active}"
+        description="">
+
+        <Receiver name="WrapGenereerDocumentIdentificatie_Di02Request">
+            <JavaListener name="WrapGenereerDocumentIdentificatie_Di02Request" returnedSessionKeys="Error" />
+        </Receiver>
+
+        <Pipeline>
+            <Exits>
+                <Exit name="EXIT" state="SUCCESS" />
+                <Exit name="EXCEPTION" state="ERROR" />
+            </Exits>
+
+            <UUIDGeneratorPipe 
+                name="GenerateReferentienummer"
+                preserveInput="true"
+                storeResultInSessionKey="Referentienummer"
+                >
+                <Forward name="success" path="CreateStuurgegevens" />
+            </UUIDGeneratorPipe>
+
+            <XsltPipe 
+                name="CreateStuurgegevens"
+                styleSheetName="Common/xsl/CreateStuurgegevens.xslt"
+                storeResultInSessionKey="Stuurgegevens"
+                >
+                <Param name="BerichtCode" value="Di02" />
+                <Param name="ZenderOrganisatie" value="${openforms2xxllnc.workflows.stuurgegevens.zender.organisatie}" />
+                <Param name="ZenderApplicatie" value="${openforms2xxllnc.workflows.stuurgegevens.zender.applicatie}" />
+                <Param name="OntvangerOrganisatie" value="${openforms2xxllnc.workflows.stuurgegevens.ontvanger.organisatie}" />
+                <Param name="OntvangerApplicatie" value="${openforms2xxllnc.workflows.stuurgegevens.ontvanger.applicatie}" />
+                <Param name="Referentienummer" sessionKey="Referentienummer" />
+                <Param name="Functie" value="genereerDocumentidentificatie" />
+                <Forward name="success" path="WrapGenereerDocumentIdentificatie_Di02Request" />
+            </XsltPipe>
+
+            <SoapWrapperPipe 
+                name="WrapGenereerDocumentIdentificatie_Di02Request"
+                getInputFromFixedValue="&lt;EmptyInput/&gt;"
+                soapBodyStyleSheet="Common/xsl/CreateGenereerDocumentIdentificatie_Di02Request.xslt"
+                >
+                <Param name="Stuurgegevens" sessionKey="Stuurgegevens" type="DOMDOC" />
+                <Forward name="success" path="EXIT" />
+            </SoapWrapperPipe>
+        </Pipeline>
+    </Adapter>
+</Module>

--- a/src/main/configurations/xxllnc/DeploymentSpecifics.properties
+++ b/src/main/configurations/xxllnc/DeploymentSpecifics.properties
@@ -21,6 +21,7 @@ Workflow_TwoWayCommunication.Active: true
 WorkflowSelector.Active: true
 WrapEdcLk01Request.Active: true
 WrapZakLv01Request.Active: true
+WrapGenereerDocumentIdentificatie_Di02Request.Active: true
 loadBalancer.url: 
 
 # suppress warning keys

--- a/src/main/resources/DeploymentSpecifics.properties
+++ b/src/main/resources/DeploymentSpecifics.properties
@@ -8,7 +8,7 @@ openforms2xxllnc.workflows.stuurgegevens.zender.organisatie=1900
 openforms2xxllnc.workflows.stuurgegevens.zender.applicatie=${instance.name}
 openforms2xxllnc.workflows.stuurgegevens.ontvanger.organisatie=1900
 openforms2xxllnc.workflows.stuurgegevens.ontvanger.applicatie=zs-dms
-openforms2xxllnc.workflows.object.dct.omschrijving=Brief
+openforms2xxllnc.workflows.object.dct.omschrijving=Bijlage webformulier
 
 application.security.jwt.allowWeakSecrets=true
 soap.bus.org.apache.cxf.stax.maxTextLength=1000000000

--- a/src/main/resources/DeploymentSpecifics.properties
+++ b/src/main/resources/DeploymentSpecifics.properties
@@ -48,6 +48,7 @@ openforms2xxllnc.connections.ontvang-asynchroon.endpoint: http://host.docker.int
 openforms2xxllnc.connections.ontvang-asynchroon.timeout: 60000
 openforms2xxllnc.connections.ontvang-asynchroon.auth-alias: zaakdms-api
 openforms2xxllnc.connections.vrije-berichten.endpoint: http://host.docker.internal:8080/services/translate/generic/zds/VrijBericht
+# openforms2xxllnc.connections.vrije-berichten.endpoint: http://host.docker.internal:8097/mock/services/translate/generic/zds/VrijBericht
 openforms2xxllnc.connections.vrije-berichten.timeout: 60000
 openforms2xxllnc.connections.vrije-berichten.auth-alias: zaakdms-api
 ## @param openforms2xxllnc.connections.notificatiesApi.rootUrl [string] Root url of the 'Notificaties API' that is used to subscribe at.

--- a/src/main/resources/DeploymentSpecifics.properties
+++ b/src/main/resources/DeploymentSpecifics.properties
@@ -8,6 +8,7 @@ openforms2xxllnc.workflows.stuurgegevens.zender.organisatie=1900
 openforms2xxllnc.workflows.stuurgegevens.zender.applicatie=${instance.name}
 openforms2xxllnc.workflows.stuurgegevens.ontvanger.organisatie=1900
 openforms2xxllnc.workflows.stuurgegevens.ontvanger.applicatie=zs-dms
+openforms2xxllnc.workflows.object.dct.omschrijving=Brief
 
 application.security.jwt.allowWeakSecrets=true
 soap.bus.org.apache.cxf.stax.maxTextLength=1000000000


### PR DESCRIPTION
- genereerDocumentIdentificatie request added.
- The documentIdentificatie generated is used in voegZaakdocumentToe message
- Add vrijeBerichten mock service for tests
- Add dct.omschrijving to voegZaakdocumentToe request with value from property